### PR TITLE
RedisConfig 환경 변수 오기입 수정

### DIFF
--- a/src/main/java/com/goorm/friendchise/global/config/RedisConfig.java
+++ b/src/main/java/com/goorm/friendchise/global/config/RedisConfig.java
@@ -12,13 +12,13 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 public class RedisConfig {
 
-    @Value("${spring.redis.host}")
+    @Value("${spring.data.redis.host}")
     private String redisHost;
 
-    @Value("${spring.redis.port}")
+    @Value("${spring.data.redis.port}")
     private int redisPort;
 
-    @Value("${spring.redis.password:}")
+    @Value("${spring.data.redis.password:}")
     private String redisPassword;
 
     @Bean


### PR DESCRIPTION
## ⚡️ 관련 이슈
- hotfix로 관련 이슈 없습니다.

## 📍주요 변경 사항
> RedisConfig 내의 Value 애노테이션의 환경변수 오기입을 수정합니다
이로 인해 실행 되지 않는 에러를 해결했습니다!

