### PR TITLE
Headquarter Store cascade 오류 해결

### DIFF
--- a/src/main/java/com/goorm/friendchise/domain/headquarter/application/HeadquarterService.java
+++ b/src/main/java/com/goorm/friendchise/domain/headquarter/application/HeadquarterService.java
@@ -67,6 +67,7 @@ public class HeadquarterService {
         findIfMine(headquarter, currentManager);
 
         headquarterRepository.deleteById(currentManager.getManageId());
+        currentManager.updateManageId(null);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/goorm/friendchise/domain/store/application/StoreService.java
+++ b/src/main/java/com/goorm/friendchise/domain/store/application/StoreService.java
@@ -91,6 +91,7 @@ public class StoreService {
         store.updateStore(req, headquarter);
     }
 
+    @Transactional
     public void deleteStore(){
         Manager currentManager = getCurrentManager();
         Store store = findIfStoreExists(currentManager);


### PR DESCRIPTION
## ⚡️ 관련 이슈
- close #60 

## 📍주요 변경 사항
> Headquarter와 Store 삭제시 Manager의 manageId가 삭제되지 않는 오류를 해결했습니다! (각 이유는 다음과 같습니다)
- Headquarter: updateManageId를 호출하지 않는 이유로 오류 발생
- Store: 하나의 Transaction으로 묶어주지 않는 이유로 오류 발생

