### PR TITLE
프로모션 생성시 ROLE 검증

### DIFF
--- a/src/main/java/com/goorm/friendchise/domain/promotion/application/PromotionService.java
+++ b/src/main/java/com/goorm/friendchise/domain/promotion/application/PromotionService.java
@@ -1,9 +1,14 @@
 package com.goorm.friendchise.domain.promotion.application;
 
+import com.goorm.friendchise.domain.manager.domain.Manager;
+import com.goorm.friendchise.domain.manager.domain.Role;
 import com.goorm.friendchise.domain.promotion.domain.Promotion;
 import com.goorm.friendchise.domain.promotion.domain.PromotionRepository;
 import com.goorm.friendchise.domain.notification.event.PromotionCreatedEvent;
 import com.goorm.friendchise.domain.promotion.dto.request.PromotionCreateRequest;
+import com.goorm.friendchise.global.auth.application.AuthService;
+import com.goorm.friendchise.global.exception.CustomException;
+import com.goorm.friendchise.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -17,9 +22,22 @@ import org.springframework.transaction.annotation.Transactional;
 public class PromotionService {
 	private final PromotionRepository promotionRepository;
 	private final ApplicationEventPublisher eventPublisher;
+	private final AuthService authService;
 
 	public void createPromotion(PromotionCreateRequest request) {
-		Promotion promotion = Promotion.create(request.headquarterId(), request.title(), request.content(), request.startDate(), request.endDate());
+		Manager manager = authService.findManagerByAuth();
+
+		if (manager.getRole() != Role.HEADQUARTER) {
+			throw new CustomException(ErrorCode.NO_AUTHENTICATION_ERROR);
+		}
+
+		Long headquarterId = manager.getManageId();
+
+		if (headquarterId == null) {
+			throw new CustomException(ErrorCode.HEADQUARTER_NOT_FOUND);
+		}
+
+		Promotion promotion = Promotion.create(headquarterId, request.title(), request.content(), request.startDate(), request.endDate());
 		promotionRepository.save(promotion);
 
 		log.info("프로모션 저장 완료: {}", promotion.getTitle());

--- a/src/main/java/com/goorm/friendchise/domain/promotion/dto/request/PromotionCreateRequest.java
+++ b/src/main/java/com/goorm/friendchise/domain/promotion/dto/request/PromotionCreateRequest.java
@@ -10,10 +10,6 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 @Builder
 public record PromotionCreateRequest(
-	@Schema(description = "본사 ID", example = "101L", requiredMode = REQUIRED)
-	@NotNull
-	Long headquarterId,
-
 	@Schema(description = "프로모션 이름", example = "깜짝 할인", requiredMode = REQUIRED)
 	@NotNull
 	String title,

--- a/src/main/java/com/goorm/friendchise/global/exception/ErrorCode.java
+++ b/src/main/java/com/goorm/friendchise/global/exception/ErrorCode.java
@@ -39,7 +39,10 @@ public enum ErrorCode {
 	NOT_FOUND_ADDRESS(HttpStatus.BAD_REQUEST, "해당 주소와 관련된 주소를 찾을 수 없습니다."),
 
 	// WebClient
-	WEBCLIENT_ERROR(HttpStatus.BAD_REQUEST, "API 호출 도중 에러가 발생했습니다.");
+	WEBCLIENT_ERROR(HttpStatus.BAD_REQUEST, "API 호출 도중 에러가 발생했습니다."),
+
+	// PROMOTION
+	NO_AUTHENTICATION_ERROR(HttpStatus.BAD_REQUEST, "본사가 아니므로 권한이 없습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/test/java/com/goorm/friendchise/domain/promotion/application/PromotionServiceTest.java
+++ b/src/test/java/com/goorm/friendchise/domain/promotion/application/PromotionServiceTest.java
@@ -1,10 +1,13 @@
 package com.goorm.friendchise.domain.promotion.application;
 
+import com.goorm.friendchise.domain.manager.domain.Manager;
+import com.goorm.friendchise.domain.manager.domain.Role;
 import com.goorm.friendchise.domain.promotion.domain.Promotion;
 import com.goorm.friendchise.domain.promotion.domain.PromotionRepository;
 import com.goorm.friendchise.domain.notification.event.PromotionCreatedEvent;
 import com.goorm.friendchise.domain.promotion.dto.request.PromotionCreateRequest;
 import com.goorm.friendchise.domain.promotion.infrastructure.FakePromotionRepository;
+import com.goorm.friendchise.global.auth.application.AuthService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -20,36 +23,72 @@ class PromotionServiceTest {
 	private PromotionService promotionService;
 	private PromotionRepository promotionRepository;
 	private ApplicationEventPublisher eventPublisher;
+	private AuthService authService;
+	private Manager headquarterManager;
+	private Manager storeManager;
 
 	@BeforeEach
 	void setUp() {
 		promotionRepository = new FakePromotionRepository();
 		eventPublisher = mock(ApplicationEventPublisher.class);
-		promotionService = new PromotionService(promotionRepository, eventPublisher);
+		authService = mock(AuthService.class);
+		promotionService = new PromotionService(promotionRepository, eventPublisher, authService);
+
+		headquarterManager = Manager.builder()
+			.username("testHQ")
+			.password("testHQ")
+			.role(Role.HEADQUARTER)
+			.manageId(1L)
+			.build();
+
+		storeManager = Manager.builder()
+			.username("testST")
+			.password("testST")
+			.role(Role.STORE)
+			.manageId(2L)
+			.build();
 	}
 
 	@Test
-	void createPromotion_success() {
-		// given
+	void 본사_관리자가_프로모션_생성_성공() {
+		when(authService.findManagerByAuth()).thenReturn(headquarterManager);
+
 		PromotionCreateRequest request = new PromotionCreateRequest(
-			1L, "깜짝적 봄맞이 할인 이벤트", "전 제품 30% 할인!",
+			"깜짝 봄맞이 할인 이벤트", "전 제품 30% 할인!",
 			LocalDateTime.of(2025, 3, 1, 9, 0),
 			LocalDateTime.of(2025, 3, 7, 23, 59)
 		);
 
-		// when
+		// When
 		promotionService.createPromotion(request);
 
-		// then
+		// Then
 		List<Promotion> promotions = promotionRepository.findAll();
 		assertThat(promotions).hasSize(1);
-		assertThat(promotions.get(0).getTitle()).isEqualTo("깜짝적 봄맞이 할인 이벤트");
+		assertThat(promotions.get(0).getTitle()).isEqualTo("깜짝 봄맞이 할인 이벤트");
 
 		// 이벤트가 정상적으로 발행되었는지 검증
 		ArgumentCaptor<PromotionCreatedEvent> eventCaptor = ArgumentCaptor.forClass(PromotionCreatedEvent.class);
 		verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());
 
 		PromotionCreatedEvent event = eventCaptor.getValue();
-		assertThat(event.getPromotion().getTitle()).isEqualTo("깜짝적 봄맞이 할인 이벤트");
+		assertThat(event.getPromotion().getTitle()).isEqualTo("깜짝 봄맞이 할인 이벤트");
+	}
+
+	@Test
+	void 본사_권한이_없는_사용자는_프로모션_생성_실패() {
+		// Given (매장 관리자)
+		when(authService.findManagerByAuth()).thenReturn(storeManager);
+
+		PromotionCreateRequest request = new PromotionCreateRequest(
+			"비정상 할인 이벤트", "허위 이벤트",
+			LocalDateTime.of(2025, 3, 1, 9, 0),
+			LocalDateTime.of(2025, 3, 7, 23, 59)
+		);
+
+		// When & Then (예외 발생 확인)
+		assertThatThrownBy(() -> promotionService.createPromotion(request))
+			.isInstanceOf(RuntimeException.class)
+			.hasMessageContaining("본사가 아니므로 권한이 없습니다.");
 	}
 }

--- a/src/test/java/com/goorm/friendchise/domain/promotion/infrastructure/FakePromotionRepository.java
+++ b/src/test/java/com/goorm/friendchise/domain/promotion/infrastructure/FakePromotionRepository.java
@@ -16,8 +16,15 @@ public class FakePromotionRepository implements PromotionRepository {
 
 	@Override
 	public void save(Promotion promotion) {
-		new Promotion(sequence.getAndIncrement(), promotion.getHeadquarterId(), promotion.getTitle(), promotion.getContent(), LocalDateTime.of(2025, 3, 1, 9, 0), LocalDateTime.of(2025, 3, 7, 20, 0));
-		promotions.add(promotion);
+		Promotion newPromotion = new Promotion(
+			sequence.getAndIncrement(),
+			promotion.getHeadquarterId(),
+			promotion.getTitle(),
+			promotion.getContent(),
+			promotion.getStartDate(),
+			promotion.getEndDate()
+		);
+		promotions.add(newPromotion);
 	}
 
 	@Override


### PR DESCRIPTION
## ⚡️ 관련 이슈
- close #62 

## 📍주요 변경 사항
> 프로모션 생성시 본사인지 확인 과정을 거쳐 생성합니다

## 🎸기타
> 현재 본사 하위 스토어 모두에게 알림을 전송합니다 (모든 스토어에서 프로모션을 진행한다고 가정)
이후 각 하위 스토어마다 프로모션 진행에 차별을 두고, 본사아이디로 알림 조회시 "본사이름" 및 "스토어 이름" 을 반환하게 기능 추가 및 리팩토링 예정입니다 

