### PR TITLE
인증 진행 후 해당 본사에서 발행한 모든 프로모션 리스트 조회

### DIFF
--- a/src/main/java/com/goorm/friendchise/domain/promotion/application/PromotionService.java
+++ b/src/main/java/com/goorm/friendchise/domain/promotion/application/PromotionService.java
@@ -6,6 +6,7 @@ import com.goorm.friendchise.domain.promotion.domain.Promotion;
 import com.goorm.friendchise.domain.promotion.domain.PromotionRepository;
 import com.goorm.friendchise.domain.notification.event.PromotionCreatedEvent;
 import com.goorm.friendchise.domain.promotion.dto.request.PromotionCreateRequest;
+import com.goorm.friendchise.domain.promotion.dto.response.PromotionDetailResponse;
 import com.goorm.friendchise.global.auth.application.AuthService;
 import com.goorm.friendchise.global.exception.CustomException;
 import com.goorm.friendchise.global.exception.ErrorCode;
@@ -14,6 +15,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -43,5 +47,17 @@ public class PromotionService {
 		log.info("프로모션 저장 완료: {}", promotion.getTitle());
 		eventPublisher.publishEvent(new PromotionCreatedEvent(promotion));
 		log.info("프로모션 이벤트 발행 완료: {}", promotion.getTitle());
+	}
+
+	public List<PromotionDetailResponse> getPromotionsByHeadquarter(Long headquarterId) {
+		List<Promotion> promotions = promotionRepository.findByHeadquarterId(headquarterId);
+		return promotions.stream()
+			.map(promotion -> PromotionDetailResponse.builder()
+				.id(promotion.getId())
+				.title(promotion.getTitle())
+				.content(promotion.getContent())
+				.startDate(promotion.getStartDate())
+				.endDate(promotion.getEndDate())
+				.build()).collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/goorm/friendchise/domain/promotion/application/PromotionService.java
+++ b/src/main/java/com/goorm/friendchise/domain/promotion/application/PromotionService.java
@@ -13,6 +13,7 @@ import com.goorm.friendchise.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -49,15 +50,25 @@ public class PromotionService {
 		log.info("프로모션 이벤트 발행 완료: {}", promotion.getTitle());
 	}
 
-	public List<PromotionDetailResponse> getPromotionsByHeadquarter(Long headquarterId) {
-		List<Promotion> promotions = promotionRepository.findByHeadquarterId(headquarterId);
-		return promotions.stream()
+	@Transactional(readOnly = true)
+	public ResponseEntity<List<PromotionDetailResponse>> getMyHeadquarterPromotions() {
+		Manager manager = authService.findManagerByAuth();
+		Long headquarterId = manager.getManageId();
+
+		if (headquarterId == null) {
+			throw new IllegalStateException("본사 정보가 없습니다.");
+		}
+
+		List<PromotionDetailResponse> promotions = promotionRepository.findByHeadquarterId(headquarterId).stream()
 			.map(promotion -> PromotionDetailResponse.builder()
 				.id(promotion.getId())
 				.title(promotion.getTitle())
 				.content(promotion.getContent())
 				.startDate(promotion.getStartDate())
 				.endDate(promotion.getEndDate())
-				.build()).collect(Collectors.toList());
+				.build())
+			.collect(Collectors.toList());
+
+		return ResponseEntity.ok(promotions);
 	}
 }

--- a/src/main/java/com/goorm/friendchise/domain/promotion/application/PromotionService.java
+++ b/src/main/java/com/goorm/friendchise/domain/promotion/application/PromotionService.java
@@ -51,7 +51,7 @@ public class PromotionService {
 	}
 
 	@Transactional(readOnly = true)
-	public ResponseEntity<List<PromotionDetailResponse>> getMyHeadquarterPromotions() {
+	public List<PromotionDetailResponse> getMyHeadquarterPromotions() {
 		Manager manager = authService.findManagerByAuth();
 		Long headquarterId = manager.getManageId();
 
@@ -59,7 +59,7 @@ public class PromotionService {
 			throw new IllegalStateException("본사 정보가 없습니다.");
 		}
 
-		List<PromotionDetailResponse> promotions = promotionRepository.findByHeadquarterId(headquarterId).stream()
+		return promotionRepository.findByHeadquarterId(headquarterId).stream()
 			.map(promotion -> PromotionDetailResponse.builder()
 				.id(promotion.getId())
 				.title(promotion.getTitle())
@@ -68,7 +68,5 @@ public class PromotionService {
 				.endDate(promotion.getEndDate())
 				.build())
 			.collect(Collectors.toList());
-
-		return ResponseEntity.ok(promotions);
 	}
 }

--- a/src/main/java/com/goorm/friendchise/domain/promotion/domain/PromotionRepository.java
+++ b/src/main/java/com/goorm/friendchise/domain/promotion/domain/PromotionRepository.java
@@ -11,4 +11,6 @@ public interface PromotionRepository {
 	Optional<Promotion> findById(Long id);
 
 	void delete(Long id);
+
+	List<Promotion> findByHeadquarterId(Long headquarterId);
 }

--- a/src/main/java/com/goorm/friendchise/domain/promotion/dto/response/PromotionDetailResponse.java
+++ b/src/main/java/com/goorm/friendchise/domain/promotion/dto/response/PromotionDetailResponse.java
@@ -1,0 +1,24 @@
+package com.goorm.friendchise.domain.promotion.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record PromotionDetailResponse(
+	@Schema(description = "프로모션 ID", example = "1")
+	Long id,
+
+	@Schema(description = "프로모션 제목", example = "봄맞이 할인")
+	String title,
+
+	@Schema(description = "프로모션 내용", example = "전 제품 30% 할인!")
+	String content,
+
+	@Schema(description = "시작일", example = "2025-03-01T09:00:00")
+	LocalDateTime startDate,
+
+	@Schema(description = "종료일", example = "2025-03-07T23:59:59")
+	LocalDateTime endDate
+) {}

--- a/src/main/java/com/goorm/friendchise/domain/promotion/infrastructure/JpaPromotionRepository.java
+++ b/src/main/java/com/goorm/friendchise/domain/promotion/infrastructure/JpaPromotionRepository.java
@@ -3,5 +3,8 @@ package com.goorm.friendchise.domain.promotion.infrastructure;
 import com.goorm.friendchise.domain.promotion.domain.Promotion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface JpaPromotionRepository extends JpaRepository<Promotion, Long> {
+	List<Promotion> findByHeadquarterId(Long headquarterId);
 }

--- a/src/main/java/com/goorm/friendchise/domain/promotion/infrastructure/PromotionRepositoryImpl.java
+++ b/src/main/java/com/goorm/friendchise/domain/promotion/infrastructure/PromotionRepositoryImpl.java
@@ -32,4 +32,9 @@ public class PromotionRepositoryImpl implements PromotionRepository {
 	public void delete(Long id) {
 		jpaPromotionRepository.deleteById(id);
 	}
+
+	@Override
+	public List<Promotion> findByHeadquarterId(Long headquarterId) {
+		return jpaPromotionRepository.findByHeadquarterId(headquarterId);
+	}
 }

--- a/src/main/java/com/goorm/friendchise/domain/promotion/presentation/PromotionController.java
+++ b/src/main/java/com/goorm/friendchise/domain/promotion/presentation/PromotionController.java
@@ -2,9 +2,12 @@ package com.goorm.friendchise.domain.promotion.presentation;
 
 import com.goorm.friendchise.domain.promotion.application.PromotionService;
 import com.goorm.friendchise.domain.promotion.dto.request.PromotionCreateRequest;
+import com.goorm.friendchise.domain.promotion.dto.response.PromotionDetailResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/promotions")
@@ -16,5 +19,11 @@ public class PromotionController {
 	public ResponseEntity<String> createPromotion(@RequestBody PromotionCreateRequest request) {
 		promotionService.createPromotion(request);
 		return ResponseEntity.ok("프로모션이 성공적으로 생성되었습니다.");
+	}
+
+	@GetMapping("/headquarter/{headquarterId}")
+	public ResponseEntity<List<PromotionDetailResponse>> getPromotionsByHeadquarter(@PathVariable Long headquarterId) {
+		List<PromotionDetailResponse> promotions = promotionService.getPromotionsByHeadquarter(headquarterId);
+		return ResponseEntity.ok(promotions);
 	}
 }

--- a/src/main/java/com/goorm/friendchise/domain/promotion/presentation/PromotionController.java
+++ b/src/main/java/com/goorm/friendchise/domain/promotion/presentation/PromotionController.java
@@ -22,7 +22,7 @@ public class PromotionController {
 	}
 
 	@GetMapping("/my")
-	public ResponseEntity<List<PromotionDetailResponse>> getMyHeadquarterPromotions() {
-		return promotionService.getMyHeadquarterPromotions();
+	public ResponseEntity<List<PromotionDetailResponse>> getMyPromotions() {
+		return ResponseEntity.ok(promotionService.getMyHeadquarterPromotions());
 	}
 }

--- a/src/main/java/com/goorm/friendchise/domain/promotion/presentation/PromotionController.java
+++ b/src/main/java/com/goorm/friendchise/domain/promotion/presentation/PromotionController.java
@@ -21,9 +21,8 @@ public class PromotionController {
 		return ResponseEntity.ok("프로모션이 성공적으로 생성되었습니다.");
 	}
 
-	@GetMapping("/headquarter/{headquarterId}")
-	public ResponseEntity<List<PromotionDetailResponse>> getPromotionsByHeadquarter(@PathVariable Long headquarterId) {
-		List<PromotionDetailResponse> promotions = promotionService.getPromotionsByHeadquarter(headquarterId);
-		return ResponseEntity.ok(promotions);
+	@GetMapping("/my")
+	public ResponseEntity<List<PromotionDetailResponse>> getMyHeadquarterPromotions() {
+		return promotionService.getMyHeadquarterPromotions();
 	}
 }

--- a/src/test/java/com/goorm/friendchise/domain/promotion/infrastructure/FakePromotionRepository.java
+++ b/src/test/java/com/goorm/friendchise/domain/promotion/infrastructure/FakePromotionRepository.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 public class FakePromotionRepository implements PromotionRepository {
 	private final List<Promotion> promotions = Collections.synchronizedList(new ArrayList<>());
@@ -40,5 +41,12 @@ public class FakePromotionRepository implements PromotionRepository {
 	@Override
 	public void delete(Long id) {
 		promotions.removeIf(promotion -> promotion.getId().equals(id));
+	}
+
+	@Override
+	public List<Promotion> findByHeadquarterId(Long headquarterId) {
+		return promotions.stream()
+			.filter(promotion -> promotion.getHeadquarterId().equals(headquarterId))
+			.collect(Collectors.toList());
 	}
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈
- close #71 

## 📍주요 변경 사항
>  본사에서 발행한 프로모션 총 리스트를 조회하는 기능을 추가하였습니다

## 🎸기타
> 본사 -> 해당 본사에서 발행한 프로모션 리스트 조회 (해당 PR 에서 구현 완료)
> 알림 -> 현재 본사에서 하위 스토어 알림을 조회하게 구현되었지만, 스토어 별로 인증을 거쳐 알림 조회 (리팩토링 예정입니다)
