### PR TITLE
각 스토어별 발생한 프로모션에 대해 알림 조회 로직 수정

### DIFF
--- a/src/main/java/com/goorm/friendchise/domain/notification/application/NotificationManager.java
+++ b/src/main/java/com/goorm/friendchise/domain/notification/application/NotificationManager.java
@@ -1,9 +1,14 @@
 package com.goorm.friendchise.domain.notification.application;
 
+import com.goorm.friendchise.domain.customer.exception.CustomerException;
 import com.goorm.friendchise.domain.headquarter.dto.store.StoreIdDto;
+import com.goorm.friendchise.domain.manager.domain.Manager;
+import com.goorm.friendchise.domain.manager.domain.Role;
 import com.goorm.friendchise.domain.notification.domain.Notification;
 import com.goorm.friendchise.domain.notification.domain.NotificationRepository;
 import com.goorm.friendchise.domain.notification.dto.response.ReceivedNotificationResponse;
+import com.goorm.friendchise.global.auth.application.AuthService;
+import com.goorm.friendchise.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,6 +22,7 @@ import java.util.stream.Collectors;
 @Slf4j
 public class NotificationManager {
 	private final NotificationRepository repository;
+	private final AuthService authService;
 
 	public List<Notification> createNotifications(List<StoreIdDto> storeIds, String title, String content) {
 		List<Notification> notifications = storeIds.stream()
@@ -45,8 +51,21 @@ public class NotificationManager {
 		repository.deleteById(notificationId);
 	}
 
-	public List<ReceivedNotificationResponse> getNotificationsByTarget(Long targetId) {
-		List<Notification> notifications = repository.findByTargetId(targetId);
+	@Transactional
+	public List<ReceivedNotificationResponse> getNotifications() {
+		Manager manager = authService.findManagerByAuth();
+
+		if (manager.getRole() != Role.STORE) {
+			throw new CustomerException(ErrorCode.NO_STORE_AUTHENTICATION_ERROR);
+		}
+
+		Long storeId = manager.getManageId();
+
+		if (storeId == null) {
+			throw new CustomerException(ErrorCode.STORE_NOT_FOUND);
+		}
+
+		List<Notification> notifications = repository.findByStoreId(storeId);
 		return notifications.stream()
 			.map(notification -> ReceivedNotificationResponse.builder()
 				.title(notification.getTitle())

--- a/src/main/java/com/goorm/friendchise/domain/notification/application/NotificationManager.java
+++ b/src/main/java/com/goorm/friendchise/domain/notification/application/NotificationManager.java
@@ -3,7 +3,7 @@ package com.goorm.friendchise.domain.notification.application;
 import com.goorm.friendchise.domain.headquarter.dto.store.StoreIdDto;
 import com.goorm.friendchise.domain.notification.domain.Notification;
 import com.goorm.friendchise.domain.notification.domain.NotificationRepository;
-import com.goorm.friendchise.domain.notification.dto.response.NotificationDetailResponse;
+import com.goorm.friendchise.domain.notification.dto.response.ReceivedNotificationResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -45,12 +45,10 @@ public class NotificationManager {
 		repository.deleteById(notificationId);
 	}
 
-	public List<NotificationDetailResponse> getNotificationsByTarget(Long targetId) {
+	public List<ReceivedNotificationResponse> getNotificationsByTarget(Long targetId) {
 		List<Notification> notifications = repository.findByTargetId(targetId);
 		return notifications.stream()
-			.map(notification -> NotificationDetailResponse.builder()
-				.id(notification.getId())
-				.targetId(notification.getTargetId())
+			.map(notification -> ReceivedNotificationResponse.builder()
 				.title(notification.getTitle())
 				.content(notification.getContent())
 				.isRead(notification.isRead())

--- a/src/main/java/com/goorm/friendchise/domain/notification/domain/NotificationRepository.java
+++ b/src/main/java/com/goorm/friendchise/domain/notification/domain/NotificationRepository.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 public interface NotificationRepository {
 	List<Notification> findAll();
 
-	List<Notification> findByTargetId(Long targetId);
+	List<Notification> findByStoreId(Long storeId);
 
 	Notification save(Notification notification);
 

--- a/src/main/java/com/goorm/friendchise/domain/notification/dto/response/ReceivedNotificationResponse.java
+++ b/src/main/java/com/goorm/friendchise/domain/notification/dto/response/ReceivedNotificationResponse.java
@@ -9,6 +9,9 @@ public record ReceivedNotificationResponse(
 	String title,
 
 	@Schema(description = "알림 내용", example = "치킨 50% 할인")
-	String content
+	String content,
+
+	@Schema(description = "읽음 여부", example = "읽음")
+	Boolean isRead
 ) {
 }

--- a/src/main/java/com/goorm/friendchise/domain/notification/infrastructure/JpaNotificationRepository.java
+++ b/src/main/java/com/goorm/friendchise/domain/notification/infrastructure/JpaNotificationRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface JpaNotificationRepository extends JpaRepository<Notification, Long> {
-	List<Notification> findByTargetId(Long targetId);
+	List<Notification> findByStoreId(Long storeId);
 }

--- a/src/main/java/com/goorm/friendchise/domain/notification/infrastructure/NotificationRepositoryImpl.java
+++ b/src/main/java/com/goorm/friendchise/domain/notification/infrastructure/NotificationRepositoryImpl.java
@@ -20,8 +20,8 @@ public class NotificationRepositoryImpl implements NotificationRepository {
 	}
 
 	@Override
-	public List<Notification> findByTargetId(Long targetId) {
-		return jpaNotificationRepository.findByTargetId(targetId);
+	public List<Notification> findByStoreId(Long storeId) {
+		return jpaNotificationRepository.findByStoreId(storeId);
 	}
 
 	@Override

--- a/src/main/java/com/goorm/friendchise/domain/notification/presentation/NotificationController.java
+++ b/src/main/java/com/goorm/friendchise/domain/notification/presentation/NotificationController.java
@@ -1,16 +1,20 @@
 package com.goorm.friendchise.domain.notification.presentation;
 
+import com.goorm.friendchise.domain.customer.exception.CustomerException;
+import com.goorm.friendchise.domain.manager.domain.Manager;
+import com.goorm.friendchise.domain.manager.domain.Role;
 import com.goorm.friendchise.domain.notification.application.NotificationManager;
 import com.goorm.friendchise.domain.notification.application.NotificationSseService;
-import com.goorm.friendchise.domain.notification.dto.response.NotificationDetailResponse;
 import com.goorm.friendchise.domain.notification.dto.response.NotificationResponse;
+import com.goorm.friendchise.domain.notification.dto.response.ReceivedNotificationResponse;
+import com.goorm.friendchise.global.auth.application.AuthService;
+import com.goorm.friendchise.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/notifications")
@@ -18,11 +22,25 @@ import java.util.stream.Collectors;
 public class NotificationController {
 	private final NotificationManager notificationManager;
 	private final NotificationSseService notificationSseService;
+	private final AuthService authService;
 
-	// 특정 targetId에 대한 알림 목록 조회 API
-	@GetMapping("/{targetId}")
-	public ResponseEntity<List<NotificationDetailResponse>> getNotifications(@PathVariable("targetId") Long targetId) {
-		List<NotificationDetailResponse> notifications = notificationManager.getNotificationsByTarget(targetId);
+	// 스토어 - 해당 스토어에 발생한 알림 조회
+	@GetMapping("/{my}")
+	public ResponseEntity<List<ReceivedNotificationResponse>> getNotifications() {
+		Manager manager = authService.findManagerByAuth();
+
+		if (manager.getRole() != Role.STORE) {
+			throw new CustomerException(ErrorCode.NO_HEADQUARTER_AUTHENTICATION_ERROR);
+		}
+
+		Long storeId = manager.getManageId();
+
+		if (storeId == null) {
+			throw new CustomerException(ErrorCode.STORE_NOT_FOUND);
+		}
+
+		List<ReceivedNotificationResponse> notifications = notificationManager.getNotificationsByTarget(storeId);
+
 		return ResponseEntity.ok(notifications);
 	}
 

--- a/src/main/java/com/goorm/friendchise/domain/notification/presentation/NotificationController.java
+++ b/src/main/java/com/goorm/friendchise/domain/notification/presentation/NotificationController.java
@@ -1,14 +1,10 @@
 package com.goorm.friendchise.domain.notification.presentation;
 
-import com.goorm.friendchise.domain.customer.exception.CustomerException;
-import com.goorm.friendchise.domain.manager.domain.Manager;
-import com.goorm.friendchise.domain.manager.domain.Role;
 import com.goorm.friendchise.domain.notification.application.NotificationManager;
 import com.goorm.friendchise.domain.notification.application.NotificationSseService;
 import com.goorm.friendchise.domain.notification.dto.response.NotificationResponse;
 import com.goorm.friendchise.domain.notification.dto.response.ReceivedNotificationResponse;
 import com.goorm.friendchise.global.auth.application.AuthService;
-import com.goorm.friendchise.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -25,22 +21,9 @@ public class NotificationController {
 	private final AuthService authService;
 
 	// 스토어 - 해당 스토어에 발생한 알림 조회
-	@GetMapping("/{my}")
+	@GetMapping("/my")
 	public ResponseEntity<List<ReceivedNotificationResponse>> getNotifications() {
-		Manager manager = authService.findManagerByAuth();
-
-		if (manager.getRole() != Role.STORE) {
-			throw new CustomerException(ErrorCode.NO_HEADQUARTER_AUTHENTICATION_ERROR);
-		}
-
-		Long storeId = manager.getManageId();
-
-		if (storeId == null) {
-			throw new CustomerException(ErrorCode.STORE_NOT_FOUND);
-		}
-
-		List<ReceivedNotificationResponse> notifications = notificationManager.getNotificationsByTarget(storeId);
-
+		List<ReceivedNotificationResponse> notifications = notificationManager.getNotifications();
 		return ResponseEntity.ok(notifications);
 	}
 

--- a/src/main/java/com/goorm/friendchise/domain/promotion/application/PromotionService.java
+++ b/src/main/java/com/goorm/friendchise/domain/promotion/application/PromotionService.java
@@ -28,7 +28,7 @@ public class PromotionService {
 		Manager manager = authService.findManagerByAuth();
 
 		if (manager.getRole() != Role.HEADQUARTER) {
-			throw new CustomException(ErrorCode.NO_AUTHENTICATION_ERROR);
+			throw new CustomException(ErrorCode.NO_HEADQUARTER_AUTHENTICATION_ERROR);
 		}
 
 		Long headquarterId = manager.getManageId();

--- a/src/main/java/com/goorm/friendchise/global/exception/ErrorCode.java
+++ b/src/main/java/com/goorm/friendchise/global/exception/ErrorCode.java
@@ -46,7 +46,10 @@ public enum ErrorCode {
 	WEBCLIENT_ERROR(HttpStatus.BAD_REQUEST, "API 호출 도중 에러가 발생했습니다."),
 
 	// PROMOTION
-	NO_AUTHENTICATION_ERROR(HttpStatus.BAD_REQUEST, "본사가 아니므로 권한이 없습니다.");
+	NO_HEADQUARTER_AUTHENTICATION_ERROR(HttpStatus.BAD_REQUEST, "본사가 아니므로 권한이 없습니다."),
+
+	// NOTIFICATION
+	NO_STORE_AUTHENTICATION_ERROR(HttpStatus.BAD_REQUEST, "스토어가 아니므로 권한이 없습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/test/java/com/goorm/friendchise/domain/notification/application/NotificationManagerTest.java
+++ b/src/test/java/com/goorm/friendchise/domain/notification/application/NotificationManagerTest.java
@@ -1,25 +1,33 @@
 package com.goorm.friendchise.domain.notification.application;
 
 import com.goorm.friendchise.domain.headquarter.dto.store.StoreIdDto;
+import com.goorm.friendchise.domain.manager.domain.Manager;
+import com.goorm.friendchise.domain.manager.domain.Role;
 import com.goorm.friendchise.domain.notification.domain.Notification;
 import com.goorm.friendchise.domain.notification.dto.response.NotificationDetailResponse;
+import com.goorm.friendchise.domain.notification.dto.response.ReceivedNotificationResponse;
 import com.goorm.friendchise.domain.notification.infrastructure.FakeNotificationRepository;
+import com.goorm.friendchise.global.auth.application.AuthService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 class NotificationManagerTest {
 	private NotificationManager notificationManager;
 	private FakeNotificationRepository repository;
+	private AuthService authService;
 
 	@BeforeEach
 	void setUp() {
 		repository = new FakeNotificationRepository();
-		notificationManager = new NotificationManager(repository);
+		authService = Mockito.mock(AuthService.class);
+		notificationManager = new NotificationManager(repository, authService);
 	}
 
 	@Test
@@ -39,19 +47,30 @@ class NotificationManagerTest {
 	}
 
 	@Test
-	@DisplayName("특정 타겟 ID로 알림을 조회할 수 있다.")
-	void getNotificationsByTarget() {
+	@DisplayName("로그인한 스토어 인증을 통해 알림을 조회할 수 있다")
+	void getNotifications() {
 		// Given
-		Notification notification1 = repository.save(Notification.create(10101L, "Title1", "Content1"));
-		Notification notification2 = repository.save(Notification.create(10101L, "Title2", "Content2"));
-		Notification notification3 = repository.save(Notification.create(10102L, "Title2", "Content2"));
+		Long storeId = 101L; // 테스트할 매장 ID
+		Manager mockManager = Manager.builder()
+			.manageId(storeId)
+			.role(Role.STORE)
+			.build();
+
+		when(authService.findManagerByAuth()).thenReturn(mockManager);
+
+		repository.save(Notification.create(101L, "Title1", "Content1"));
+		repository.save(Notification.create(101L, "Title2", "Content2"));
+		repository.save(Notification.create(102L, "Title3", "Content3")); // 다른 스토어 ID
 
 		// When
-		List<NotificationDetailResponse> foundNotifications = notificationManager.getNotificationsByTarget(10101L);
+		List<ReceivedNotificationResponse> foundNotifications = notificationManager.getNotifications();
 
 		// Then
-		assertThat(foundNotifications).hasSize(2);
+		assertThat(foundNotifications).hasSize(2); // storeId=101L인 알림만 조회됨
+		assertThat(foundNotifications).extracting("title").contains("Title1", "Title2");
+		verify(authService, times(1)).findManagerByAuth(); // 인증 메서드가 1회 호출되었는지 검증
 	}
+
 
 	@Test
 	@DisplayName("알림을 읽음 처리할 수 있다.")

--- a/src/test/java/com/goorm/friendchise/domain/notification/infrastructure/FakeNotificationRepository.java
+++ b/src/test/java/com/goorm/friendchise/domain/notification/infrastructure/FakeNotificationRepository.java
@@ -20,7 +20,7 @@ public class FakeNotificationRepository implements NotificationRepository {
 	}
 
 	@Override
-	public List<Notification> findByTargetId(Long targetId) {
+	public List<Notification> findByStoreId(Long targetId) {
 		return notifications.stream().filter(notification -> notification.getTargetId().equals(targetId)).collect(Collectors.toList());
 	}
 


### PR DESCRIPTION
## ⚡️ 관련 이슈
- close #73 

## 📍주요 변경 사항
> 데이터 조회시 TargetId 라는 모호한 메서드명을 StoreId로 변경하였습니다
> id 값을 파라미터로 넘겨받지않고, 로그인한 스토어 인증정보를 통해 Id를 추출하여 인증을 진행합니다

## 🎸기타
> 고려해야 하는 내용을 작성해 주세요.

