### PR TITLE
스토어 권한 확인 및 공통 로직 리팩토링 

### DIFF
--- a/src/main/java/com/goorm/friendchise/domain/notification/application/NotificationEventHandler.java
+++ b/src/main/java/com/goorm/friendchise/domain/notification/application/NotificationEventHandler.java
@@ -33,6 +33,8 @@ public class NotificationEventHandler {
 		List<Notification> notifications = notificationManager.createNotifications(storeIds, title, content);
 
 		// SSE 전송
-		storeIds.forEach(storeId -> notificationSseService.sendSse(storeId.id(), title, content));
+		notifications.forEach(notification ->
+			notificationSseService.sendSse(notification.getStoreId(), notification.getTitle(), notification.getContent())
+		);
 	}
 }

--- a/src/main/java/com/goorm/friendchise/domain/notification/application/NotificationEventHandler.java
+++ b/src/main/java/com/goorm/friendchise/domain/notification/application/NotificationEventHandler.java
@@ -22,19 +22,22 @@ public class NotificationEventHandler {
 	@EventListener
 	public void handlePromotionCreated(PromotionCreatedEvent promotion) {
 		log.info("프로모션 생성 이벤트 감지 완료: {}", promotion);
+		List<Notification> notifications = processPromotionNotification(promotion);
+		sendNotifications(notifications);
+	}
 
+	private List<Notification> processPromotionNotification(PromotionCreatedEvent promotion) {
 		Long headquarterId = promotion.getPromotion().getHeadquarterId();
 		String title = promotion.getPromotion().getTitle();
 		String content = promotion.getPromotion().getContent();
 
 		List<StoreIdDto> storeIds = headquarterService.getStoreIdList(headquarterId);
+		return notificationManager.createNotifications(storeIds, title, content);
+	}
 
-		// 알림 생성 요청
-		List<Notification> notifications = notificationManager.createNotifications(storeIds, title, content);
-
-		// SSE 전송
+	private void sendNotifications(List<Notification> notifications) {
 		notifications.forEach(notification ->
-			notificationSseService.sendSse(notification.getStoreId(), notification.getTitle(), notification.getContent())
+			notificationSseSender.sendSse(notification.getStoreId(), notification.getTitle(), notification.getContent())
 		);
 	}
 }

--- a/src/main/java/com/goorm/friendchise/domain/notification/application/NotificationEventHandler.java
+++ b/src/main/java/com/goorm/friendchise/domain/notification/application/NotificationEventHandler.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class NotificationEventHandler {
 	private final HeadquarterService headquarterService;
 	private final NotificationManager notificationManager;
-	private final NotificationSseService notificationSseService;
+	private final NotificationSseSender notificationSseSender;
 
 	@EventListener
 	public void handlePromotionCreated(PromotionCreatedEvent promotion) {

--- a/src/main/java/com/goorm/friendchise/domain/notification/application/NotificationManager.java
+++ b/src/main/java/com/goorm/friendchise/domain/notification/application/NotificationManager.java
@@ -24,16 +24,12 @@ public class NotificationManager {
 	private final NotificationRepository repository;
 	private final AuthService authService;
 
-	private Manager getAuthManager() {
-		return authService.findManagerByAuth();
-	}
-
 	private Manager getAuthStoreManager() {
-		Manager authManager = getAuthManager();
-		if (authManager.getRole() != Role.STORE) {
+		Manager manager = authService.findManagerByAuth();
+		if (manager.getRole() != Role.STORE) {
 			throw new CustomException(ErrorCode.NO_STORE_AUTHENTICATION_ERROR);
 		}
-		return authManager;
+		return manager;
 	}
 
 	public List<Notification> createNotifications(List<StoreIdDto> storeIds, String title, String content) {

--- a/src/main/java/com/goorm/friendchise/domain/notification/application/NotificationManager.java
+++ b/src/main/java/com/goorm/friendchise/domain/notification/application/NotificationManager.java
@@ -1,6 +1,5 @@
 package com.goorm.friendchise.domain.notification.application;
 
-import com.goorm.friendchise.domain.customer.exception.CustomerException;
 import com.goorm.friendchise.domain.headquarter.dto.store.StoreIdDto;
 import com.goorm.friendchise.domain.manager.domain.Manager;
 import com.goorm.friendchise.domain.manager.domain.Role;
@@ -54,10 +53,19 @@ public class NotificationManager {
 
 	@Transactional
 	public void markAsRead(Long notificationId) {
+		Manager storeManager = getAuthStoreManager();
+		Long storeId = storeManager.getManageId();
+
 		Notification notification = repository.findById(notificationId)
-			.orElseThrow(() -> new IllegalArgumentException("알림을 찾을 수 없습니다."));
+			.orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+		if (!notification.getStoreId().equals(storeId)) {
+			throw new CustomException(ErrorCode.NO_STORE_EQUAL_AUTHENTICATION_ERROR);
+		}
+
 		notification.markAsRead();
 	}
+
 
 	@Transactional
 	public void deleteNotification(Long notificationId) {
@@ -66,17 +74,8 @@ public class NotificationManager {
 
 	@Transactional
 	public List<ReceivedNotificationResponse> getNotifications() {
-		Manager manager = authService.findManagerByAuth();
-
-		if (manager.getRole() != Role.STORE) {
-			throw new CustomerException(ErrorCode.NO_STORE_AUTHENTICATION_ERROR);
-		}
-
-		Long storeId = manager.getManageId();
-
-		if (storeId == null) {
-			throw new CustomerException(ErrorCode.STORE_NOT_FOUND);
-		}
+		Manager storeManager = getAuthStoreManager();
+		Long storeId = storeManager.getManageId();
 
 		List<Notification> notifications = repository.findByStoreId(storeId);
 		return notifications.stream()

--- a/src/main/java/com/goorm/friendchise/domain/notification/application/NotificationManager.java
+++ b/src/main/java/com/goorm/friendchise/domain/notification/application/NotificationManager.java
@@ -8,6 +8,7 @@ import com.goorm.friendchise.domain.notification.domain.Notification;
 import com.goorm.friendchise.domain.notification.domain.NotificationRepository;
 import com.goorm.friendchise.domain.notification.dto.response.ReceivedNotificationResponse;
 import com.goorm.friendchise.global.auth.application.AuthService;
+import com.goorm.friendchise.global.exception.CustomException;
 import com.goorm.friendchise.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +24,18 @@ import java.util.stream.Collectors;
 public class NotificationManager {
 	private final NotificationRepository repository;
 	private final AuthService authService;
+
+	private Manager getAuthManager() {
+		return authService.findManagerByAuth();
+	}
+
+	private Manager getAuthStoreManager() {
+		Manager authManager = getAuthManager();
+		if (authManager.getRole() != Role.STORE) {
+			throw new CustomException(ErrorCode.NO_STORE_AUTHENTICATION_ERROR);
+		}
+		return authManager;
+	}
 
 	public List<Notification> createNotifications(List<StoreIdDto> storeIds, String title, String content) {
 		List<Notification> notifications = storeIds.stream()

--- a/src/main/java/com/goorm/friendchise/domain/notification/application/NotificationSseSender.java
+++ b/src/main/java/com/goorm/friendchise/domain/notification/application/NotificationSseSender.java
@@ -43,15 +43,18 @@ public class NotificationSseSender {
 		}
 
 		emitter.onCompletion(() -> {
-			log.info("SSE 연결 종료: targetId = {}", targetId);
-			emitters.remove(targetId);
+			removeEmitter("SSE 연결 종료", targetId);
 		});
 
 		emitter.onTimeout(() -> {
-			log.info("SSE 타임아웃 발생: targetId = {}", targetId);
-			emitters.remove(targetId);
+			removeEmitter("SSE 타임 아웃", targetId);
 		});
 
 		return emitter;
+	}
+
+	private void removeEmitter(String reason, Long targetId) {
+		log.info("{}: {}", reason, targetId);
+		emitters.remove(targetId);
 	}
 }

--- a/src/main/java/com/goorm/friendchise/domain/notification/application/NotificationSseSender.java
+++ b/src/main/java/com/goorm/friendchise/domain/notification/application/NotificationSseSender.java
@@ -12,7 +12,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class NotificationSseService {
+public class NotificationSseSender {
 	private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
 
 	public void sendSse(Long targetId, String title, String content) {

--- a/src/main/java/com/goorm/friendchise/domain/notification/domain/Notification.java
+++ b/src/main/java/com/goorm/friendchise/domain/notification/domain/Notification.java
@@ -17,7 +17,7 @@ public class Notification extends BaseEntity {
 	private Long id;
 
 	@Column(nullable = false)
-	private Long targetId; // 매장 ID (무조건 STORE)
+	private Long storeId;
 
 	@Column(nullable = false, length = 100)
 	private String title;
@@ -30,7 +30,7 @@ public class Notification extends BaseEntity {
 
 	public static Notification create(Long storeId, String title, String content) {
 		return Notification.builder()
-			.targetId(storeId)
+			.storeId(storeId)
 			.title(title)
 			.content(content)
 			.isRead(false)

--- a/src/main/java/com/goorm/friendchise/domain/notification/presentation/NotificationController.java
+++ b/src/main/java/com/goorm/friendchise/domain/notification/presentation/NotificationController.java
@@ -1,7 +1,7 @@
 package com.goorm.friendchise.domain.notification.presentation;
 
 import com.goorm.friendchise.domain.notification.application.NotificationManager;
-import com.goorm.friendchise.domain.notification.application.NotificationSseService;
+import com.goorm.friendchise.domain.notification.application.NotificationSseSender;
 import com.goorm.friendchise.domain.notification.dto.response.NotificationResponse;
 import com.goorm.friendchise.domain.notification.dto.response.ReceivedNotificationResponse;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +16,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NotificationController {
 	private final NotificationManager notificationManager;
-	private final NotificationSseService notificationSseService;
+	private final NotificationSseSender notificationSseSender;
 
 	// 스토어 - 해당 스토어에 발생한 알림 조회
 	@GetMapping("/my")
@@ -42,6 +42,6 @@ public class NotificationController {
 	// SSE 구독 (매장 실시간 알림 받기)
 	@GetMapping("/subscribe/{targetId}")
 	public SseEmitter subscribe(@PathVariable("targetId") Long targetId) {
-		return notificationSseService.subscribe(targetId);
+		return notificationSseSender.subscribe(targetId);
 	}
 }

--- a/src/main/java/com/goorm/friendchise/domain/notification/presentation/NotificationController.java
+++ b/src/main/java/com/goorm/friendchise/domain/notification/presentation/NotificationController.java
@@ -4,7 +4,6 @@ import com.goorm.friendchise.domain.notification.application.NotificationManager
 import com.goorm.friendchise.domain.notification.application.NotificationSseService;
 import com.goorm.friendchise.domain.notification.dto.response.NotificationResponse;
 import com.goorm.friendchise.domain.notification.dto.response.ReceivedNotificationResponse;
-import com.goorm.friendchise.global.auth.application.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,7 +17,6 @@ import java.util.List;
 public class NotificationController {
 	private final NotificationManager notificationManager;
 	private final NotificationSseService notificationSseService;
-	private final AuthService authService;
 
 	// 스토어 - 해당 스토어에 발생한 알림 조회
 	@GetMapping("/my")
@@ -29,14 +27,14 @@ public class NotificationController {
 
 	//  알림 읽음 처리
 	@PatchMapping("/{notificationId}/read")
-	public ResponseEntity<NotificationResponse> markAsRead(@PathVariable Long notificationId) {
+	public ResponseEntity<NotificationResponse> markAsRead(@PathVariable("notificationId") Long notificationId) {
 		notificationManager.markAsRead(notificationId);
 		return ResponseEntity.ok(new NotificationResponse(notificationId, "success", "알림이 읽음 처리되었습니다."));
 	}
 
 	//  알림 삭제
 	@DeleteMapping("/{notificationId}")
-	public ResponseEntity<NotificationResponse> deleteNotification(@PathVariable Long notificationId) {
+	public ResponseEntity<NotificationResponse> deleteNotification(@PathVariable("notificationId") Long notificationId) {
 		notificationManager.deleteNotification(notificationId);
 		return ResponseEntity.ok(new NotificationResponse(notificationId, "success", "알림이 삭제되었습니다."));
 	}

--- a/src/main/java/com/goorm/friendchise/global/exception/ErrorCode.java
+++ b/src/main/java/com/goorm/friendchise/global/exception/ErrorCode.java
@@ -17,11 +17,11 @@ public enum ErrorCode {
 	NEAR_STORE_NOT_FOUND(HttpStatus.BAD_REQUEST, "가까운 매장을 찾을 수 없습니다."),
 	//Customer Error
 	RECOMMEND_API_TIMEOUT(HttpStatus.BAD_REQUEST, "추천 API 호출 중 타임아웃 발생"),
-	UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"알 수 없는 에러"),
+	UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 에러"),
 	// Auth Error
-	DUPLICATE_LOGIN_ID(HttpStatus.BAD_REQUEST,"중복된 아이디입니다."),
-	INVALID_PASSWORD(HttpStatus.BAD_REQUEST,"유효하지 않은 비밀번호입니다."),
-	LOGIN_FAIL(HttpStatus.UNAUTHORIZED,"아이디 또는 비밀번호가 틀립니다."),
+	DUPLICATE_LOGIN_ID(HttpStatus.BAD_REQUEST, "중복된 아이디입니다."),
+	INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "유효하지 않은 비밀번호입니다."),
+	LOGIN_FAIL(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 틀립니다."),
 	PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
 	HEADQUARTER_AUTH_NOT_MATCH(HttpStatus.BAD_REQUEST, "본사 인증번호가 일치하지 않습니다."),
 	TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않거나 만료된 토큰입니다."),
@@ -30,7 +30,7 @@ public enum ErrorCode {
 	// Headquarter Error
 	FRANCHISE_NAME_DUPLICATION(HttpStatus.BAD_REQUEST, "이미 존재하는 프랜차이즈 이름입니다."),
 	HEADQUARTER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 프랜차이즈 본사입니다."),
-    FRANCHISE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 프랜차이즈입니다."),
+	FRANCHISE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 프랜차이즈입니다."),
 	FRANCHISE_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 상위 카테고리입니다."),
 	FRANCHISE_SUBCATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 하위 카테고리입니다."),
 	COORDINATE_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "좌표에 해당하는 행정동을 찾을 수 없습니다."),
@@ -41,7 +41,7 @@ public enum ErrorCode {
 	STORE_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 매장을 찾을 수 없습니다."),
 	SALES_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 매출을 찾을 수 없습니다."),
 	NOT_FOUND_ADDRESS(HttpStatus.BAD_REQUEST, "해당 주소와 관련된 주소를 찾을 수 없습니다."),
-
+	NO_STORE_EQUAL_AUTHENTICATION_ERROR(HttpStatus.BAD_REQUEST, "해당 스토어와 다른 스토어이므로 접근할 수 없습니다"),
 	// WebClient
 	WEBCLIENT_ERROR(HttpStatus.BAD_REQUEST, "API 호출 도중 에러가 발생했습니다."),
 
@@ -49,7 +49,8 @@ public enum ErrorCode {
 	NO_HEADQUARTER_AUTHENTICATION_ERROR(HttpStatus.BAD_REQUEST, "본사가 아니므로 권한이 없습니다."),
 
 	// NOTIFICATION
-	NO_STORE_AUTHENTICATION_ERROR(HttpStatus.BAD_REQUEST, "스토어가 아니므로 권한이 없습니다.");
+	NO_STORE_AUTHENTICATION_ERROR(HttpStatus.BAD_REQUEST, "스토어가 아니므로 권한이 없습니다."),
+	NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 알림입니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/test/java/com/goorm/friendchise/domain/notification/application/NotificationEventHandlerTest.java
+++ b/src/test/java/com/goorm/friendchise/domain/notification/application/NotificationEventHandlerTest.java
@@ -2,6 +2,7 @@ package com.goorm.friendchise.domain.notification.application;
 
 import com.goorm.friendchise.domain.headquarter.application.HeadquarterService;
 import com.goorm.friendchise.domain.headquarter.dto.store.StoreIdDto;
+import com.goorm.friendchise.domain.notification.domain.Notification;
 import com.goorm.friendchise.domain.notification.event.PromotionCreatedEvent;
 import com.goorm.friendchise.domain.promotion.domain.Promotion;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,7 +26,7 @@ class NotificationEventHandlerTest {
 	private NotificationManager notificationManager;
 
 	@Mock
-	private NotificationSseService notificationSseService;
+	private NotificationSseSender notificationSseSender;
 
 	@InjectMocks
 	private NotificationEventHandler eventHandler;
@@ -36,28 +37,34 @@ class NotificationEventHandlerTest {
 	}
 
 	@Test
-	@DisplayName("프로모션 생성 이벤트를 처리하고 알림을 생성한다.")
+	@DisplayName("프로모션 생성 이벤트를 처리하고 알림을 생성 후 SSE를 전송한다.")
 	void handlePromotionCreated() {
 		// Given
 		Long headquarterId = 1L;
 		String title = "New Promotion";
 		String content = "Promotion Details";
 
-		List<Long> storeIds = List.of(10101L, 10102L);
+		List<StoreIdDto> storeIds = List.of(new StoreIdDto(10101L), new StoreIdDto(10102L));
 		Promotion promotion = Promotion.create(headquarterId, title, content,
 			LocalDateTime.of(2025, 3, 1, 9, 0),
 			LocalDateTime.of(2025, 3, 7, 23, 59)
 		);
 		PromotionCreatedEvent event = new PromotionCreatedEvent(promotion);
 
-		when(headquarterService.getStoreIdList(headquarterId))
-			.thenReturn(List.of(new StoreIdDto(10101L), new StoreIdDto(10102L)));
+		List<Notification> mockedNotifications = storeIds.stream()
+			.map(storeId -> Notification.create(storeId.id(), title, content))
+			.toList();
+
+		when(headquarterService.getStoreIdList(headquarterId)).thenReturn(storeIds);
+		when(notificationManager.createNotifications(storeIds, title, content)).thenReturn(mockedNotifications);
 
 		// When
 		eventHandler.handlePromotionCreated(event);
 
 		// Then
-		verify(notificationManager, times(1)).createNotifications(List.of(new StoreIdDto(10101L), new StoreIdDto(10102L)), title, content);
-		storeIds.forEach(storeId -> verify(notificationSseService, times(1)).sendSse(storeId, title, content));
+		verify(notificationManager, times(1)).createNotifications(storeIds, title, content);
+
+		mockedNotifications.forEach(notification -> verify(notificationSseSender, times(1))
+			.sendSse(notification.getStoreId(), notification.getTitle(), notification.getContent()));
 	}
 }

--- a/src/test/java/com/goorm/friendchise/domain/notification/application/NotificationManagerTest.java
+++ b/src/test/java/com/goorm/friendchise/domain/notification/application/NotificationManagerTest.java
@@ -4,7 +4,6 @@ import com.goorm.friendchise.domain.headquarter.dto.store.StoreIdDto;
 import com.goorm.friendchise.domain.manager.domain.Manager;
 import com.goorm.friendchise.domain.manager.domain.Role;
 import com.goorm.friendchise.domain.notification.domain.Notification;
-import com.goorm.friendchise.domain.notification.dto.response.NotificationDetailResponse;
 import com.goorm.friendchise.domain.notification.dto.response.ReceivedNotificationResponse;
 import com.goorm.friendchise.domain.notification.infrastructure.FakeNotificationRepository;
 import com.goorm.friendchise.global.auth.application.AuthService;
@@ -47,10 +46,10 @@ class NotificationManagerTest {
 	}
 
 	@Test
-	@DisplayName("로그인한 스토어 인증을 통해 알림을 조회할 수 있다")
+	@DisplayName("로그인한 스토어 인증을 통해 알림을 조회할 수 있다.")
 	void getNotifications() {
 		// Given
-		Long storeId = 101L; // 테스트할 매장 ID
+		Long storeId = 101L;
 		Manager mockManager = Manager.builder()
 			.manageId(storeId)
 			.role(Role.STORE)
@@ -66,18 +65,25 @@ class NotificationManagerTest {
 		List<ReceivedNotificationResponse> foundNotifications = notificationManager.getNotifications();
 
 		// Then
-		assertThat(foundNotifications).hasSize(2); // storeId=101L인 알림만 조회됨
+		assertThat(foundNotifications).hasSize(2);
 		assertThat(foundNotifications).extracting("title").contains("Title1", "Title2");
-		verify(authService, times(1)).findManagerByAuth(); // 인증 메서드가 1회 호출되었는지 검증
+		verify(authService, times(1)).findManagerByAuth();
 	}
-
 
 	@Test
 	@DisplayName("알림을 읽음 처리할 수 있다.")
 	void markAsRead() {
 		// Given
-		Notification notification = repository.save(Notification.create(101L, "Title", "Content"));
+		Long storeId = 101L;
+		Notification notification = repository.save(Notification.create(storeId, "Title", "Content"));
 		Long notificationId = notification.getId();
+
+		Manager mockManager = Manager.builder()
+			.manageId(storeId)
+			.role(Role.STORE)
+			.build();
+
+		when(authService.findManagerByAuth()).thenReturn(mockManager);
 
 		// When
 		notificationManager.markAsRead(notificationId);

--- a/src/test/java/com/goorm/friendchise/domain/notification/application/NotificationSseServiceTest.java
+++ b/src/test/java/com/goorm/friendchise/domain/notification/application/NotificationSseServiceTest.java
@@ -10,11 +10,11 @@ import java.io.IOException;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class NotificationSseServiceTest {
-	private NotificationSseService sseService;
+	private NotificationSseSender sseSender;
 
 	@BeforeEach
 	void setUp() {
-		sseService = new NotificationSseService();
+		sseSender = new NotificationSseSender();
 	}
 
 	@Test
@@ -24,7 +24,7 @@ class NotificationSseServiceTest {
 		Long targetId = 101L;
 
 		// When
-		SseEmitter emitter = sseService.subscribe(targetId);
+		SseEmitter emitter = sseSender.subscribe(targetId);
 
 		// Then
 		assertThat(emitter).isNotNull();
@@ -35,15 +35,15 @@ class NotificationSseServiceTest {
 	void sendSse() throws IOException {
 		// Given
 		Long targetId = 101L;
-		SseEmitter emitter = sseService.subscribe(targetId);
+		SseEmitter emitter = sseSender.subscribe(targetId);
 		String title = "New Promotion";
 		String content = "Promotion Content";
 
 		// When
-		sseService.sendSse(targetId, title, content);
+		sseSender.sendSse(targetId, title, content);
 
 		// Then
 		// SSEEmitter 내부 동작을 직접 검증하기 어려우므로, 로그 또는 정상 동작 확인
-		assertThat(sseService.subscribe(targetId)).isNotNull();
+		assertThat(sseSender.subscribe(targetId)).isNotNull();
 	}
 }

--- a/src/test/java/com/goorm/friendchise/domain/notification/infrastructure/FakeNotificationRepository.java
+++ b/src/test/java/com/goorm/friendchise/domain/notification/infrastructure/FakeNotificationRepository.java
@@ -21,14 +21,14 @@ public class FakeNotificationRepository implements NotificationRepository {
 
 	@Override
 	public List<Notification> findByStoreId(Long targetId) {
-		return notifications.stream().filter(notification -> notification.getTargetId().equals(targetId)).collect(Collectors.toList());
+		return notifications.stream().filter(notification -> notification.getStoreId().equals(targetId)).collect(Collectors.toList());
 	}
 
 	@Override
 	public Notification save(Notification notification) {
 		Notification savedNotification = new Notification(
 			sequence.getAndIncrement(),
-			notification.getTargetId(),
+			notification.getStoreId(),
 			notification.getTitle(),
 			notification.getContent(),
 			false


### PR DESCRIPTION
## ⚡️ 관련 이슈
- close #75 

## 📍주요 변경 사항
> 알림 조회시 해당 스토어의 매니저만 읽음 처리 할 수 있게 로직을 추가하였습니다
알림 서비스의 SSE 연결/전송 및 이벤트발생/하위스토어조회 등에 사용되는 공통 로직을 추출 및 메서드를 분리하였습니다


## 🎸기타
> 

