### PR TITLE
Feat/본사 마이페이지에 인증 번호 추가

### DIFF
--- a/src/main/java/com/goorm/friendchise/domain/manager/application/ManagerService.java
+++ b/src/main/java/com/goorm/friendchise/domain/manager/application/ManagerService.java
@@ -19,6 +19,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.goorm.friendchise.domain.manager.domain.Role.HEADQUARTER;
 import static com.goorm.friendchise.domain.manager.domain.Role.STORE;
 import static com.goorm.friendchise.global.exception.ErrorCode.HEADQUARTER_NOT_FOUND;
 import static com.goorm.friendchise.global.exception.ErrorCode.INVALID_PARAMETER;
@@ -68,6 +69,12 @@ public class ManagerService {
 
 	public ManagerDetailResponse mypage() {
 		Manager manager = authService.findManagerByAuth();
+
+		if (manager.getRole().equals(HEADQUARTER)) {
+			Headquarter headquarter = headquarterRepository.findById(manager.getManageId())
+				.orElseThrow(() -> new CustomException(HEADQUARTER_NOT_FOUND));
+			return ManagerDetailResponse.fromHeadquarter(manager, headquarter.getCertificationNumber());
+		}
 		return ManagerDetailResponse.from(manager);
 	}
 

--- a/src/main/java/com/goorm/friendchise/domain/manager/dto/response/ManagerDetailResponse.java
+++ b/src/main/java/com/goorm/friendchise/domain/manager/dto/response/ManagerDetailResponse.java
@@ -9,7 +9,8 @@ public record ManagerDetailResponse(
 	Long id,
 	String username,
 	Role role,
-	Long manageId
+	Long manageId,
+	String certificationNumber
 ) {
 	public static ManagerDetailResponse from(Manager manager) {
 		return ManagerDetailResponse.builder()
@@ -17,6 +18,16 @@ public record ManagerDetailResponse(
 			.username(manager.getUsername())
 			.role(manager.getRole())
 			.manageId(manager.getManageId())
+			.build();
+	}
+
+	public static ManagerDetailResponse fromHeadquarter(Manager manager, String headquarterCertificationNumber) {
+		return ManagerDetailResponse.builder()
+			.id(manager.getId())
+			.username(manager.getUsername())
+			.role(manager.getRole())
+			.manageId(manager.getManageId())
+			.certificationNumber(headquarterCertificationNumber)
 			.build();
 	}
 }

--- a/src/test/java/com/goorm/friendchise/domain/headquarter/insfrastructure/FakeHeadquarterRepository.java
+++ b/src/test/java/com/goorm/friendchise/domain/headquarter/insfrastructure/FakeHeadquarterRepository.java
@@ -2,12 +2,12 @@ package com.goorm.friendchise.domain.headquarter.insfrastructure;
 
 import com.goorm.friendchise.domain.headquarter.domain.Headquarter;
 import com.goorm.friendchise.domain.headquarter.domain.HeadquarterRepository;
-import com.goorm.friendchise.domain.notification.domain.Notification;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class FakeHeadquarterRepository implements HeadquarterRepository {
@@ -20,6 +20,7 @@ public class FakeHeadquarterRepository implements HeadquarterRepository {
                 .franchiseName(headquarter.getFranchiseName())
                 .category(headquarter.getCategory())
                 .subCategory(headquarter.getSubCategory())
+            	.certificationNumber(UUID.randomUUID().toString())
                 .build();
         headquarters.add(savedHeadquarter);
         return savedHeadquarter;

--- a/src/test/java/com/goorm/friendchise/domain/manager/application/ManagerServiceTest.java
+++ b/src/test/java/com/goorm/friendchise/domain/manager/application/ManagerServiceTest.java
@@ -40,7 +40,6 @@ import static com.goorm.friendchise.domain.manager.domain.Role.STORE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 class ManagerServiceTest {
 	private ManagerService managerService;
@@ -61,9 +60,15 @@ class ManagerServiceTest {
 		managerService = new ManagerService(managerRepository, bCryptPasswordEncoder,
 			authService, headquarterRepository, notificationSseSender);
 
-		managerRepository.save(
+		Manager savedManager = managerRepository.save(
 			Manager.create("test", "test1234", HEADQUARTER)
 		);
+
+		Headquarter headquarter = headquarterRepository.save(
+			Headquarter.of("Mcdonald", Category.FASTFOOD, SubCategory.NONE)
+		);
+
+		savedManager.updateManageId(headquarter.getId());
 
 		UserDetails manger = managerService.findManagerByUsername("test");
 		SecurityContext context = SecurityContextHolder.getContext();
@@ -163,7 +168,7 @@ class ManagerServiceTest {
 		assertEquals(1L, detail.id());
 		assertEquals(inputName, detail.username());
 		assertEquals(HEADQUARTER, detail.role());
-		assertNull(detail.manageId());
+		assertEquals(1L, detail.manageId());
 	}
 
 	@Test
@@ -177,6 +182,8 @@ class ManagerServiceTest {
 		assertEquals(1L, mypage.id());
 		assertEquals("test", mypage.username());
 		assertEquals(HEADQUARTER, mypage.role());
+		assertEquals(1L, mypage.manageId());
+		assertNotNull(mypage.certificationNumber());
 	}
 
 	@Test
@@ -236,7 +243,7 @@ class ManagerServiceTest {
 		assertEquals(inputName, manager.getUsername());
 		assertEquals("test1234", manager.getPassword());
 		assertEquals(HEADQUARTER, manager.getRole());
-		assertNull(manager.getManageId());
+		assertEquals(1L, manager.getManageId());
 	}
 
 	@Test


### PR DESCRIPTION
## ⚡️ 관련 이슈
- close #111 

## 📍주요 변경 사항
> 당초 프론트에서 인증번호를 확인할 수 있는 방법이 없었습니다.
그래서 본사 마이페이지에 Reponse에 인증번호를 추가했습니다.
