### PR TITLE
Feature/store recommendation streaming

### DIFF
--- a/src/main/java/com/goorm/friendchise/domain/headquarter/application/KakaoApiClient.java
+++ b/src/main/java/com/goorm/friendchise/domain/headquarter/application/KakaoApiClient.java
@@ -78,6 +78,7 @@ public class KakaoApiClient {
                 .bodyToMono(KakaoApiResultDto.class)
                 .timeout(Duration.ofSeconds(3))
                 .retryWhen(Retry.backoff(3, Duration.ofMillis(200))
+                        .filter(throwable -> throwable instanceof CustomException) // 4xx 에러의 경우 재시도 X
                         .jitter(0.5));
     }
 }

--- a/src/main/java/com/goorm/friendchise/domain/headquarter/application/OpenAiApiService.java
+++ b/src/main/java/com/goorm/friendchise/domain/headquarter/application/OpenAiApiService.java
@@ -4,6 +4,7 @@ import com.goorm.friendchise.domain.headquarter.dto.openai.*;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
 
 import java.util.List;
 
@@ -38,12 +39,23 @@ public class OpenAiApiService {
     public ChatCompletionResponseDto requestChatCompletion(String data) {
         ChatMessage developerRoleMsg = ChatMessage.of(OpenAiRole.DEVELOPER.getValue(), initialSettingMessage);
         ChatMessage userRoleMsg = ChatMessage.of(OpenAiRole.USER.getValue(), data);
-        ChatCompletionRequestDto chatCompletionRequestDto = ChatCompletionRequestDto.of(OpenAiModel.GPT_4o_MINI.getValue(), List.of(developerRoleMsg, userRoleMsg));
+        ChatCompletionRequestDto chatCompletionRequestDto = ChatCompletionRequestDto.of(OpenAiModel.GPT_4o_MINI.getValue(), List.of(developerRoleMsg, userRoleMsg), false);
 
         return webClient.post()
                 .bodyValue(chatCompletionRequestDto)
                 .retrieve()
                 .bodyToMono(ChatCompletionResponseDto.class)
                 .block();
+    }
+
+    public Flux<ChatCompletionResponseDto> requestChatCompletionStream(String data) {
+        ChatMessage developerRoleMsg = ChatMessage.of(OpenAiRole.DEVELOPER.getValue(), initialSettingMessage);
+        ChatMessage userRoleMsg = ChatMessage.of(OpenAiRole.USER.getValue(), data);
+        ChatCompletionRequestDto chatCompletionRequestDto = ChatCompletionRequestDto.of(OpenAiModel.GPT_4o_MINI.getValue(), List.of(developerRoleMsg, userRoleMsg), true);
+
+        return webClient.post()
+                .bodyValue(chatCompletionRequestDto)
+                .retrieve()
+                .bodyToFlux(ChatCompletionResponseDto.class);
     }
 }

--- a/src/main/java/com/goorm/friendchise/domain/headquarter/application/OpenAiApiService.java
+++ b/src/main/java/com/goorm/friendchise/domain/headquarter/application/OpenAiApiService.java
@@ -1,11 +1,16 @@
 package com.goorm.friendchise.domain.headquarter.application;
 
 import com.goorm.friendchise.domain.headquarter.dto.openai.*;
+import com.goorm.friendchise.global.exception.CustomException;
+import com.goorm.friendchise.global.exception.ErrorCode;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 
@@ -58,6 +63,18 @@ public class OpenAiApiService {
                 .bodyValue(chatCompletionRequestDto)
                 .accept(MediaType.TEXT_EVENT_STREAM)
                 .retrieve()
-                .bodyToFlux(String.class);
+                .bodyToFlux(ChatCompletionStreamResponseDto.class)
+                .onErrorResume(error -> {
+                    if (error.getMessage().contains("JsonToken.START_ARRAY")) {
+                        return Flux.empty();
+                    } else {
+                        return Flux.error(error);
+                    }
+                })
+                .filter(response -> {
+                    String content = response.choices().get(0).getDelta().getContent();
+                    return content != null;
+                })
+                .map(response -> response.choices().get(0).getDelta().getContent());
     }
 }

--- a/src/main/java/com/goorm/friendchise/domain/headquarter/application/OpenAiApiService.java
+++ b/src/main/java/com/goorm/friendchise/domain/headquarter/application/OpenAiApiService.java
@@ -2,6 +2,7 @@ package com.goorm.friendchise.domain.headquarter.application;
 
 import com.goorm.friendchise.domain.headquarter.dto.openai.*;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
@@ -48,14 +49,15 @@ public class OpenAiApiService {
                 .block();
     }
 
-    public Flux<ChatCompletionResponseDto> requestChatCompletionStream(String data) {
+    public Flux<String> requestChatCompletionStream(String data) {
         ChatMessage developerRoleMsg = ChatMessage.of(OpenAiRole.DEVELOPER.getValue(), initialSettingMessage);
         ChatMessage userRoleMsg = ChatMessage.of(OpenAiRole.USER.getValue(), data);
         ChatCompletionRequestDto chatCompletionRequestDto = ChatCompletionRequestDto.of(OpenAiModel.GPT_4o_MINI.getValue(), List.of(developerRoleMsg, userRoleMsg), true);
 
         return webClient.post()
                 .bodyValue(chatCompletionRequestDto)
+                .accept(MediaType.TEXT_EVENT_STREAM)
                 .retrieve()
-                .bodyToFlux(ChatCompletionResponseDto.class);
+                .bodyToFlux(String.class);
     }
 }

--- a/src/main/java/com/goorm/friendchise/domain/headquarter/application/StoreRecommendationService.java
+++ b/src/main/java/com/goorm/friendchise/domain/headquarter/application/StoreRecommendationService.java
@@ -101,7 +101,6 @@ public class StoreRecommendationService {
                 req.x());
 
         if(mono == null) { // 반경 500m 내 동일한 프랜차이즈 매장이 존재할 경우
-//            StreamChoice choice = StreamChoice.of(0, new Delta("반경 500m 내 동일한 프랜차이즈 매장이 존재합니다."));
             return Flux.just("반경 500m 내 동일한 프랜차이즈 매장이 존재합니다.");
         }
 

--- a/src/main/java/com/goorm/friendchise/domain/headquarter/application/StoreRecommendationService.java
+++ b/src/main/java/com/goorm/friendchise/domain/headquarter/application/StoreRecommendationService.java
@@ -9,6 +9,9 @@ import com.goorm.friendchise.domain.headquarter.dto.kakaomap.KakaoApiResultDto;
 import com.goorm.friendchise.domain.headquarter.dto.kakaomap.KakaoPlaceDto;
 import com.goorm.friendchise.domain.headquarter.dto.openai.ChatCompletionResponseDto;
 import com.goorm.friendchise.domain.headquarter.dto.openai.ChatCompletionResponseDto.Choice;
+import com.goorm.friendchise.domain.headquarter.dto.openai.ChatCompletionStreamResponseDto;
+import com.goorm.friendchise.domain.headquarter.dto.openai.ChatCompletionStreamResponseDto.Delta;
+import com.goorm.friendchise.domain.headquarter.dto.openai.ChatCompletionStreamResponseDto.StreamChoice;
 import com.goorm.friendchise.domain.headquarter.dto.openai.ChatMessage;
 import com.goorm.friendchise.global.aop.ExecutionTime;
 import com.goorm.friendchise.global.exception.CustomException;
@@ -80,7 +83,7 @@ public class StoreRecommendationService {
         return res;
     }
 
-    public Flux<ChatCompletionResponseDto> getRecommendationStream(StoreRecommendReqDto req) {
+    public Flux<String> getRecommendationStream(StoreRecommendReqDto req) {
         // franchiseName, category, subCategory SecurityContextHolder 에서 가져와서 keyword로 사용
         StringBuilder sb = new StringBuilder();
         CommercialArea area = commercialAreaService.getCommercialArea(req.x(), req.y());
@@ -98,8 +101,8 @@ public class StoreRecommendationService {
                 req.x());
 
         if(mono == null) { // 반경 500m 내 동일한 프랜차이즈 매장이 존재할 경우
-            Choice choice = Choice.of(ChatMessage.of("assistant", "반경 500m 내 동일한 프랜차이즈 매장이 존재합니다."));
-            return Flux.just(ChatCompletionResponseDto.of(List.of(choice), new ChatCompletionResponseDto.Usage(0, 0)));
+//            StreamChoice choice = StreamChoice.of(0, new Delta("반경 500m 내 동일한 프랜차이즈 매장이 존재합니다."));
+            return Flux.just("반경 500m 내 동일한 프랜차이즈 매장이 존재합니다.");
         }
 
         Map<String, KakaoApiResultDto> totalPlaceData = mono.block();

--- a/src/main/java/com/goorm/friendchise/domain/headquarter/application/StoreRecommendationService.java
+++ b/src/main/java/com/goorm/friendchise/domain/headquarter/application/StoreRecommendationService.java
@@ -16,6 +16,7 @@ import com.goorm.friendchise.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.*;
@@ -77,6 +78,46 @@ public class StoreRecommendationService {
         int totalTokens = res.usage().getCompletionTokens() + res.usage().getPromptTokens();
         log.info("전체 사용 토큰 수: {}", totalTokens);
         return res;
+    }
+
+    public Flux<ChatCompletionResponseDto> getRecommendationStream(StoreRecommendReqDto req) {
+        // franchiseName, category, subCategory SecurityContextHolder 에서 가져와서 keyword로 사용
+        StringBuilder sb = new StringBuilder();
+        CommercialArea area = commercialAreaService.getCommercialArea(req.x(), req.y());
+        sb.append("m² 당 임대료: ").append(area.getRentalFee()).append("\n");
+
+        Headquarter headquarter = headquarterService.getHeadquarterByContext();
+
+        List<String> userSelectedCategory = getUserSelectedCategory(req);
+        Mono<Map<String, KakaoApiResultDto>> mono = kakaoApiService.getTotalPlaceData(
+                headquarter.getFranchiseName(),
+                headquarter.getCategory(),
+                headquarter.getSubCategory(),
+                userSelectedCategory,
+                req.y(),
+                req.x());
+
+        if(mono == null) { // 반경 500m 내 동일한 프랜차이즈 매장이 존재할 경우
+            Choice choice = Choice.of(ChatMessage.of("assistant", "반경 500m 내 동일한 프랜차이즈 매장이 존재합니다."));
+            return Flux.just(ChatCompletionResponseDto.of(List.of(choice), new ChatCompletionResponseDto.Usage(0, 0)));
+        }
+
+        Map<String, KakaoApiResultDto> totalPlaceData = mono.block();
+
+        // 카카오 API로부터 받아온 데이터를 OpenAI API에 넘길 데이터로 파싱
+        totalPlaceData.forEach((key, value) -> {
+            List<KakaoPlaceDto> documents = value.documents();
+            String distances = documents.stream()
+                    .map(KakaoPlaceDto::distance)
+                    .map(String::valueOf)
+                    .collect(Collectors.joining(", "));
+            sb.append(key).append(": [").append(distances).append("]\n");
+        });
+
+        String data = sb.toString();
+        log.info("openAi api에 사용될 데이터 메시지: {}", data);
+
+        return openAiApiService.requestChatCompletionStream(data);
     }
 
     public ChatCompletionResponseDto getRecommendationDummy(StoreRecommendReqDto req) throws InterruptedException {

--- a/src/main/java/com/goorm/friendchise/domain/headquarter/dto/headquarter/HeadquarterDetailResDto.java
+++ b/src/main/java/com/goorm/friendchise/domain/headquarter/dto/headquarter/HeadquarterDetailResDto.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.goorm.friendchise.domain.headquarter.domain.Headquarter;
 
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record HeadquarterDetailResDto(
         Long id,
         String franchiseName,

--- a/src/main/java/com/goorm/friendchise/domain/headquarter/dto/headquarter/HeadquarterDetailResDto.java
+++ b/src/main/java/com/goorm/friendchise/domain/headquarter/dto/headquarter/HeadquarterDetailResDto.java
@@ -1,7 +1,10 @@
 package com.goorm.friendchise.domain.headquarter.dto.headquarter;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.goorm.friendchise.domain.headquarter.domain.Headquarter;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record HeadquarterDetailResDto(
         Long id,
         String franchiseName,

--- a/src/main/java/com/goorm/friendchise/domain/headquarter/dto/openai/ChatCompletionRequestDto.java
+++ b/src/main/java/com/goorm/friendchise/domain/headquarter/dto/openai/ChatCompletionRequestDto.java
@@ -10,10 +10,11 @@ import java.util.List;
 public record ChatCompletionRequestDto(
         String model,
         List<ChatMessage> messages,
-        double temperature
+        double temperature,
+        boolean stream
 ){
 
-    public static ChatCompletionRequestDto of(String model, List<ChatMessage> chatMessages) {
-        return new ChatCompletionRequestDto(model, chatMessages, 0);
+    public static ChatCompletionRequestDto of(String model, List<ChatMessage> chatMessages, boolean stream) {
+        return new ChatCompletionRequestDto(model, chatMessages, 0, stream);
     }
 }

--- a/src/main/java/com/goorm/friendchise/domain/headquarter/dto/openai/ChatCompletionStreamResponseDto.java
+++ b/src/main/java/com/goorm/friendchise/domain/headquarter/dto/openai/ChatCompletionStreamResponseDto.java
@@ -3,6 +3,7 @@ package com.goorm.friendchise.domain.headquarter.dto.openai;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
@@ -11,7 +12,7 @@ import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record ChatCompletionStreamResponseDto(
-        List<ChatCompletionStreamResponseDto> chatCompletionStreamResponseDtos,
+        String id,
         List<StreamChoice> choices
 ) {
     @Getter
@@ -19,11 +20,10 @@ public record ChatCompletionStreamResponseDto(
     @ToString
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class StreamChoice {
-        private final int index;
         private final Delta delta;
 
-        public static StreamChoice of(int index, Delta delta) {
-            return new StreamChoice(index, delta);
+        public static StreamChoice of(Delta delta) {
+            return new StreamChoice(delta);
         }
     }
 

--- a/src/main/java/com/goorm/friendchise/domain/headquarter/dto/openai/ChatCompletionStreamResponseDto.java
+++ b/src/main/java/com/goorm/friendchise/domain/headquarter/dto/openai/ChatCompletionStreamResponseDto.java
@@ -1,0 +1,37 @@
+package com.goorm.friendchise.domain.headquarter.dto.openai;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ChatCompletionStreamResponseDto(
+        List<ChatCompletionStreamResponseDto> chatCompletionStreamResponseDtos,
+        List<StreamChoice> choices
+) {
+    @Getter
+    @RequiredArgsConstructor
+    @ToString
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class StreamChoice {
+        private final int index;
+        private final Delta delta;
+
+        public static StreamChoice of(int index, Delta delta) {
+            return new StreamChoice(index, delta);
+        }
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    @ToString
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Delta {
+        private final String content;
+    }
+}

--- a/src/main/java/com/goorm/friendchise/domain/headquarter/presentation/HeadquarterController.java
+++ b/src/main/java/com/goorm/friendchise/domain/headquarter/presentation/HeadquarterController.java
@@ -10,6 +10,7 @@ import com.goorm.friendchise.domain.headquarter.dto.headquarter.HeadquarterReqDt
 import com.goorm.friendchise.domain.headquarter.dto.headquarter.HeadquarterResDto;
 import com.goorm.friendchise.domain.headquarter.dto.headquarter.StoreRecommendReqDto;
 import com.goorm.friendchise.domain.headquarter.dto.openai.ChatCompletionResponseDto;
+import com.goorm.friendchise.domain.headquarter.dto.openai.ChatCompletionStreamResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.converters.models.PageableAsQueryParam;
@@ -72,7 +73,7 @@ public class HeadquarterController {
     }
 
     @PostMapping(value = "/store-recommendation-stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public ResponseEntity<Flux<ChatCompletionResponseDto>> getRecommendationStreamResult(@Valid @RequestBody StoreRecommendReqDto req) {
+    public ResponseEntity<Flux<String>> getRecommendationStreamResult(@Valid @RequestBody StoreRecommendReqDto req) {
         return ResponseEntity.ok().body(storeRecommendationService.getRecommendationStream(req));
     }
 

--- a/src/main/java/com/goorm/friendchise/domain/headquarter/presentation/HeadquarterController.java
+++ b/src/main/java/com/goorm/friendchise/domain/headquarter/presentation/HeadquarterController.java
@@ -15,9 +15,11 @@ import lombok.RequiredArgsConstructor;
 import org.springdoc.core.converters.models.PageableAsQueryParam;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
 
 import java.net.URI;
 import java.util.List;
@@ -67,6 +69,11 @@ public class HeadquarterController {
     @PostMapping("/store-recommendation")
     public ResponseEntity<ChatCompletionResponseDto> getRecommendationResult(@Valid @RequestBody StoreRecommendReqDto req) {
         return ResponseEntity.ok().body(storeRecommendationService.getRecommendation(req));
+    }
+
+    @PostMapping(value = "/store-recommendation-stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public ResponseEntity<Flux<ChatCompletionResponseDto>> getRecommendationStreamResult(@Valid @RequestBody StoreRecommendReqDto req) {
+        return ResponseEntity.ok().body(storeRecommendationService.getRecommendationStream(req));
     }
 
     @PostMapping("/store-recommendation-dummy")

--- a/src/main/java/com/goorm/friendchise/global/config/SecurityConfig.java
+++ b/src/main/java/com/goorm/friendchise/global/config/SecurityConfig.java
@@ -74,7 +74,8 @@ public class SecurityConfig {
 		"/manager/**",
 		"/notifications/**",
 		"/promotions/**",
-			"/headquarter/store-recommendation-dummy"
+			"/headquarter/store-recommendation-dummy",
+			"/headquarter/store-recommendation-stream",
 	};
 
 	CorsConfigurationSource corsConfigurationSource() {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,41 @@
+server:
+  port: ${PORT:8080}
+
+spring:
+  config:
+    import: optional:file:.env[.properties]
+  application:
+    name: friendchise
+  datasource:
+    url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:friendchise}
+    username: ${DB_USERNAME:root}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+      default_batch_fetch_size: 1000
+      jdbc:
+        time_zone: Asia/Seoul
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+    defer-datasource-initialization: true
+    show-sql: true
+    open-in-view: false
+    database-platform: org.hibernate.spatial.dialect.MySQL8SpatialDialect
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: ${REDIS_PASSWORD}
+
+kakao:
+  apiKey: ${KAKAO_API_KEY}
+  api:
+    findPosition: /search/address.json
+    convert-position-into-info: /geo/coord2regioncode.JSON
+
+jwt:
+  issuer: ${JWT_ISSUER}
+  secret: ${JWT_SECRET}


### PR DESCRIPTION
## ⚡️ 관련 이슈
- close #117 

## 📍주요 변경 사항
> openai api 스트리밍 처리
스트리밍 처리를 위해 응답 반환으로 flux를 사용했는데 webflux는 security 처리가 별도로 해야한다고 해서..(확실하진않음) 암튼 403에러때매 /headquarter/store-recommendation-stream은 permitAll에 추가했습니다 (다만 토큰으로부터 manageId 추출해서 headquarter 정보를 가져와야 하긴 하므로 로그인 필요)

## 🎸기타
> 고려해야 하는 내용을 작성해 주세요.

