### PR TITLE
Feat/역할 기반으로 인증 인가 설정

### DIFF
--- a/src/main/java/com/goorm/friendchise/domain/headquarter/presentation/HeadquarterController.java
+++ b/src/main/java/com/goorm/friendchise/domain/headquarter/presentation/HeadquarterController.java
@@ -16,6 +16,7 @@ import org.springdoc.core.converters.models.PageableAsQueryParam;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,6 +27,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Validated
 @RequestMapping("/headquarter")
+@Secured("ROLE_HEADQUARTER")
 public class HeadquarterController {
     private final HeadquarterService headquarterService;
     private final ItemService itemService;

--- a/src/main/java/com/goorm/friendchise/domain/headquarter/presentation/HeadquarterController.java
+++ b/src/main/java/com/goorm/friendchise/domain/headquarter/presentation/HeadquarterController.java
@@ -27,45 +27,51 @@ import java.util.List;
 @RequiredArgsConstructor
 @Validated
 @RequestMapping("/headquarter")
-@Secured("ROLE_HEADQUARTER")
 public class HeadquarterController {
     private final HeadquarterService headquarterService;
     private final ItemService itemService;
     private final StoreRecommendationService storeRecommendationService;
 
+    @Secured("ROLE_HEADQUARTER")
     @PostMapping("/register")
     public ResponseEntity<HeadquarterResDto> createHeadquarter(@Valid @RequestBody HeadquarterReqDto headquarterReqDto) {
         return ResponseEntity.created(URI.create("/headquarter")).body(headquarterService.createHeadquarter(headquarterReqDto));
     }
 
+    @Secured("ROLE_HEADQUARTER")
     @GetMapping
     public ResponseEntity<HeadquarterDetailResDto> getHeadquarter() {
         return ResponseEntity.ok().body(headquarterService.getHeadquarter());
     }
 
     // 엔티티 전체 필드가 들어오는 경우 PUT, 일부만 들어오는 경우 PATCH로 구분하는게 맞을거같은데..그냥 PATCH로 구현
+    @Secured("ROLE_HEADQUARTER")
     @PatchMapping("/update")
     public ResponseEntity<HeadquarterResDto> updateHeadquarter(@Valid @RequestBody HeadquarterReqDto headquarterReqDto) {
         return ResponseEntity.ok().body(headquarterService.updateHeadquarterName(headquarterReqDto));
     }
 
+    @Secured("ROLE_HEADQUARTER")
     @DeleteMapping
     public ResponseEntity<Void> deleteHeadquarter() {
         headquarterService.deleteHeadquarter();
         return ResponseEntity.ok().body(null);
     }
 
+    @Secured("ROLE_HEADQUARTER")
     @PageableAsQueryParam
     @GetMapping("/items")
     public ResponseEntity<Slice<ItemResDto>> getItems(Pageable pageable) {
         return ResponseEntity.ok().body(itemService.getItemsNative(pageable));
     }
 
+    @Secured("ROLE_HEADQUARTER")
     @PostMapping("/items/register")
     public ResponseEntity<List<ItemResDto>> createItems(@Valid @RequestBody ItemReqDtoList itemReqDtoList) {
         return ResponseEntity.created(URI.create("/headquarter/items")).body(itemService.createItems(itemReqDtoList));
     }
 
+    @Secured("ROLE_HEADQUARTER")
     @PostMapping("/store-recommendation")
     public ResponseEntity<ChatCompletionResponseDto> getRecommendationResult(@Valid @RequestBody StoreRecommendReqDto req) {
         return ResponseEntity.ok().body(storeRecommendationService.getRecommendation(req));

--- a/src/main/java/com/goorm/friendchise/domain/manager/application/ManagerService.java
+++ b/src/main/java/com/goorm/friendchise/domain/manager/application/ManagerService.java
@@ -62,11 +62,6 @@ public class ManagerService {
 		return authService.managerLogin(manager);
 	}
 
-	public ManagerDetailResponse detail(String username) {
-		Manager manager = findManagerByUsername(username);
-		return ManagerDetailResponse.from(manager);
-	}
-
 	public ManagerDetailResponse mypage() {
 		Manager manager = authService.findManagerByAuth();
 

--- a/src/main/java/com/goorm/friendchise/domain/manager/presentation/ManagerController.java
+++ b/src/main/java/com/goorm/friendchise/domain/manager/presentation/ManagerController.java
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -43,13 +42,6 @@ public class ManagerController {
 		@RequestBody @Valid ManageLoginRequest request
 	) {
 		return ResponseEntity.ok(managerService.login(request));
-	}
-
-	@GetMapping("/{username}")
-	public ResponseEntity<ManagerDetailResponse> userDetail(
-		@PathVariable String username
-	) {
-		return ResponseEntity.ok(managerService.detail(username));
 	}
 
 	@GetMapping("/mypage")

--- a/src/main/java/com/goorm/friendchise/domain/manager/presentation/ManagerController.java
+++ b/src/main/java/com/goorm/friendchise/domain/manager/presentation/ManagerController.java
@@ -12,6 +12,7 @@ import com.goorm.friendchise.global.auth.dto.response.TokenResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -49,6 +50,7 @@ public class ManagerController {
 		return ResponseEntity.ok(managerService.mypage());
 	}
 
+	@Secured({"ROLE_HEADQUARTER", "ROLE_STORE"})
 	@PutMapping("/update/store-id")
 	public ResponseEntity<Void> update(
 		@RequestParam Long newStoreId
@@ -57,6 +59,7 @@ public class ManagerController {
 		return ResponseEntity.noContent().build();
 	}
 
+	@Secured({"ROLE_HEADQUARTER", "ROLE_STORE"})
 	@PutMapping("/update/password")
 	public ResponseEntity<Void> updatePassword(
 		@RequestBody @Valid ManagerPasswordRequest request

--- a/src/main/java/com/goorm/friendchise/domain/notification/presentation/NotificationController.java
+++ b/src/main/java/com/goorm/friendchise/domain/notification/presentation/NotificationController.java
@@ -6,6 +6,7 @@ import com.goorm.friendchise.domain.notification.dto.response.NotificationRespon
 import com.goorm.friendchise.domain.notification.dto.response.ReceivedNotificationResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -14,6 +15,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/notifications")
 @RequiredArgsConstructor
+@Secured("ROLE_STORE")
 public class NotificationController {
 	private final NotificationManager notificationManager;
 	private final NotificationSseSender notificationSseSender;

--- a/src/main/java/com/goorm/friendchise/domain/promotion/presentation/PromotionController.java
+++ b/src/main/java/com/goorm/friendchise/domain/promotion/presentation/PromotionController.java
@@ -5,6 +5,7 @@ import com.goorm.friendchise.domain.promotion.dto.request.PromotionCreateRequest
 import com.goorm.friendchise.domain.promotion.dto.response.PromotionDetailResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -12,6 +13,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/promotions")
 @RequiredArgsConstructor
+@Secured("ROLE_HEADQUARTER")
 public class PromotionController {
 	private final PromotionService promotionService;
 

--- a/src/main/java/com/goorm/friendchise/domain/store/presentation/SalesController.java
+++ b/src/main/java/com/goorm/friendchise/domain/store/presentation/SalesController.java
@@ -13,11 +13,13 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/store")
+@Secured("ROLE_STORE")
 public class SalesController {
 
     private final SalesService salesService;

--- a/src/main/java/com/goorm/friendchise/domain/store/presentation/SalesController.java
+++ b/src/main/java/com/goorm/friendchise/domain/store/presentation/SalesController.java
@@ -2,7 +2,6 @@ package com.goorm.friendchise.domain.store.presentation;
 
 
 import com.goorm.friendchise.domain.store.application.SalesService;
-import com.goorm.friendchise.domain.store.domain.Sales;
 import com.goorm.friendchise.domain.store.dto.SalesDetailedResDto;
 import com.goorm.friendchise.domain.store.dto.SalesReqDto;
 import com.goorm.friendchise.domain.store.dto.SalesResDto;
@@ -10,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.HttpStatus;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;

--- a/src/main/java/com/goorm/friendchise/domain/store/presentation/StoreController.java
+++ b/src/main/java/com/goorm/friendchise/domain/store/presentation/StoreController.java
@@ -6,6 +6,7 @@ import com.goorm.friendchise.domain.store.dto.StoreReqDto;
 import com.goorm.friendchise.domain.store.dto.res.KakaoApiAddressResDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -13,6 +14,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/store")
+@Secured("ROLE_STORE")
 public class StoreController {
 
     private final StoreService storeService;

--- a/src/main/java/com/goorm/friendchise/global/config/SecurityConfig.java
+++ b/src/main/java/com/goorm/friendchise/global/config/SecurityConfig.java
@@ -68,13 +68,11 @@ public class SecurityConfig {
 		"/",
 	};
 
-	// TODO 추후 권한별 분리 할때 세분화
 	private static final String[] PUBLIC_ENDPOINTS = {
-		"/customer/**",
-		"/manager/**",
-		"/notifications/**",
-		"/promotions/**",
-			"/headquarter/store-recommendation-dummy"
+		"*/register",
+		"*/login",
+		"*/reissue",
+		"/headquarter/store-recommendation-dummy"
 	};
 
 	CorsConfigurationSource corsConfigurationSource() {

--- a/src/test/java/com/goorm/friendchise/domain/manager/application/ManagerServiceTest.java
+++ b/src/test/java/com/goorm/friendchise/domain/manager/application/ManagerServiceTest.java
@@ -156,23 +156,6 @@ class ManagerServiceTest {
 	}
 
 	@Test
-	@DisplayName("detail은 입력된 username으로 ManagerDetailResponse를 반환")
-	void detail_success() {
-		// given
-		String inputName = "test";
-
-		// when
-		ManagerDetailResponse detail = managerService.detail(inputName);
-
-		// then
-		assertNotNull(detail);
-		assertEquals(1L, detail.id());
-		assertEquals(inputName, detail.username());
-		assertEquals(HEADQUARTER, detail.role());
-		assertEquals(1L, detail.manageId());
-	}
-
-	@Test
 	@DisplayName("mypage는 SecurityContextHolder의 정보로 ManagerDetailResponse를 반환")
 	void mypage_success() {
 		// when


### PR DESCRIPTION
## ⚡️ 관련 이슈
- close #130 

## 📍주요 변경 사항
> 당초 개발 편의를 위해 인증인가를 따로 설정하지 않았지만 기능 개발이 종료되었다고 판단했습니다.
그래서 역할 기반으로 인증인가를 설정했습니다.
각 API별 접근 가능한 역할은 다음과 같습니다.

API | 역할
-- | --
회원 가입, 로그인, 재발급 | 모두 가능
모든 customer/ | 모두 가능
/headquarter/store-recommendation-dummy | 모두 가능 
/headquarter/store-recommendation-stream | 모두 가능
나머지 manager/ | 본사, 매장
모든 promotions/ | 본사
나머지 headquarter/ | 본사
모든 store/ | 매장
모든 notifications/ | 매장
